### PR TITLE
Reset all forms on bug view page with the reset form button

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ tiqit (1.0.5-1) trusty; urgency=low
   * Fixes to the make_deb script.
   * Gracefully handle searches updating between 0 and 1 results.
   * Sort search fields by display name, rather than internal name.
+  * Reset all forms on the bug page with the reset button.
 
  -- Jonathan Loh <joloh@ensoft.co.uk> Wed, 4 Jul 2018 15:30:00 +0100
 

--- a/scripts/pages/view.py
+++ b/scripts/pages/view.py
@@ -230,7 +230,7 @@ def displayGeneral(hide=False):
 <div id='extraCopies'></div>
 <p>
  <input type='submit' value='Save Changes'>
- <input type='button' value='Reset Form' onclick='this.form.reset(); checkChildren(); checkFormValidity();'>
+ <input type='button' value='Reset Form' onclick='resetForm();'>
  <input type='button' onclick='if (!amEditing || confirm("You&apos;ve made changes to this bug. Cloning it will throw them away. Are you sure you want to continue?")) document.location = "newbug.py?bugid=%(Identifier)s";' value='Clone Bug'>
 </p>
 </form>""" % args

--- a/static/scripts/view.js
+++ b/static/scripts/view.js
@@ -520,6 +520,19 @@ function getFieldValueView(field) {
     }
 }
 
+function resetForm() {
+    // Want to reset both initial form and extras form.
+    document.getElementById("tiqitBugEdit").reset();
+    document.getElementById("tiqitExtraFormData").reset();
+
+    // Also clear the indicator on the Component name if it has been set - 
+    // not being reset in checkFormValidity().
+    element = document.getElementById("Component");
+    Tiqit.clearIndicator(element);
+
+    checkChildren();
+    checkFormValidity();
+}
 
 function checkChildren() {
     var ev = new Object();


### PR DESCRIPTION
Ensures the "Reset Form" button on the bug view page actually resets all of the forms, rather than just the primary form.