### PR TITLE
Bugfix/default filename

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ tiqit (1.0.5-1) trusty; urgency=low
   * Fixes to the make_deb script.
   * Gracefully handle searches updating between 0 and 1 results.
   * Sort search fields by display name, rather than internal name.
+  * Set attachment titles to filenames by default.
 
  -- Jonathan Loh <joloh@ensoft.co.uk> Wed, 4 Jul 2018 15:30:00 +0100
 

--- a/scripts/actions/addfile.py
+++ b/scripts/actions/addfile.py
@@ -9,6 +9,8 @@ args = Arguments()
 # Get a temporary file to put the attachment into
 filename = args.writeToTempFile('theFile')
 
+queueMessage(MSG_WARNING, "Filename: '{}'".format(args['fileTitle']))
+
 try:
     addAttachment(args['bugid'], args['fileTitle'], filename)
 

--- a/scripts/pages/view.py
+++ b/scripts/pages/view.py
@@ -324,14 +324,14 @@ def displayNotes(hide=False):
  <form action='addfile.py' method='post' enctype='multipart/form-data'>
   <input type='hidden' name='bugid' value='%s'>
   <p>
-   Title: <input name='fileTitle' type='text' size='50'>
+   Title: <input id='fileTitle' name='fileTitle' type='text' size='50' value="" onchange='unsetDefault()'>
 <!--
    Type: <select name='fileType'>
     <option value='Auto'>Auto</option>
     <option value='Text'>Text</option>
    </select>
 -->
-   <input type='file' name='theFile' size='30'>
+   <input type='file' id='theFile' name='theFile' size='30' onchange='updateFileName()'>
   </p>
   <p>
    <input type='submit' value='Save'>

--- a/static/scripts/view.js
+++ b/static/scripts/view.js
@@ -842,3 +842,26 @@ function prepareForm() {
   else
     return true;
 }
+
+//
+// Update the default file name when a file is entered
+//
+var default_being_used = true;
+
+function updateFileName() {
+  var encTitle = document.getElementById("fileTitle");
+  var fileInput = document.getElementById("theFile");
+
+  var fileName = fileInput.files.item(0).name.split('.', 1)[0];
+
+  //window.alert(fileName);
+
+  if (fileTitle.value == "" || default_being_used) {
+      fileTitle.value = fileName;
+      default_being_used = true;
+  }
+}
+
+function unsetDefault() {
+    default_being_used = false;
+}

--- a/static/scripts/view.js
+++ b/static/scripts/view.js
@@ -856,8 +856,8 @@ function updateFileName() {
 
   //window.alert(fileName);
 
-  if (fileTitle.value == "" || default_being_used) {
-      fileTitle.value = fileName;
+  if (encTitle.value == "" || default_being_used) {
+      encTitle.value = fileName;
       default_being_used = true;
   }
 }


### PR DESCRIPTION
Sets attachment title to filename by default. Does not change if a typed attachment title is present.

Tests:

- Add file, see title change
- Change file, see title change
- Set title and change files, see no title change
- Remove set title, and change files, see title change