### PR TITLE
Tiqit 1.0.5 release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+debian/copyright

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,8 @@ tiqit (1.0.5-1) trusty; urgency=low
   * Fixes to the make_deb script.
   * Gracefully handle searches updating between 0 and 1 results.
   * Sort search fields by display name, rather than internal name.
+  * Stop logical operators being changed when removing entries from
+    a compound search.
 
  -- Jonathan Loh <joloh@ensoft.co.uk> Wed, 4 Jul 2018 15:30:00 +0100
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ tiqit (1.0.5-1) trusty; urgency=low
   * Fixes to the make_deb script.
   * Gracefully handle searches updating between 0 and 1 results.
   * Sort search fields by display name, rather than internal name.
+  * Don't clear the search box when changing condition from is to is not.
   * Set attachment titles to filenames by default.
   * Stop logical operators being changed when removing entries from
     a compound search.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+tiqit (1.0.5-1) trusty; urgency=low
+
+  * Fixes to the make_deb script.
+
+ -- Jonathan Loh <joloh@ensoft.co.uk>  Fri, 24 Mar 2017 13:10:00 +0100
+
 tiqit (1.0.4-1) trusty; urgency=low
 
   * Fixes to the make_deb script.

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ tiqit (1.0.5-1) trusty; urgency=low
 
   * Fixes to the make_deb script.
   * Gracefully handle searches updating between 0 and 1 results.
+  * Sort search fields by display name, rather than internal name.
 
  -- Jonathan Loh <joloh@ensoft.co.uk> Wed, 4 Jul 2018 15:30:00 +0100
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ tiqit (1.0.5-1) trusty; urgency=low
   * Fixes to the make_deb script.
   * Gracefully handle searches updating between 0 and 1 results.
   * Sort search fields by display name, rather than internal name.
+  * Stop severity graph overflow.
   * Reset all forms on the bug page with the reset button.
   * Don't clear the search box when changing condition from is to is not.
   * Set attachment titles to filenames by default.

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ tiqit (1.0.5-1) trusty; urgency=low
   * Fixes to the make_deb script.
   * Gracefully handle searches updating between 0 and 1 results.
   * Sort search fields by display name, rather than internal name.
+  * Set attachment titles to filenames by default.
   * Stop logical operators being changed when removing entries from
     a compound search.
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+tiqit (1.0.6-1) trusty; urgency=low
+
+  * Added missing code for config directories
+
+ -- Jonathan Loh <joloh@ensoft.co.uk> Thurs, 15 Nov 2018 15:30:00 +0100
+
 tiqit (1.0.5-1) trusty; urgency=low
 
   * Fixes to the make_deb script.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,3 @@
-tiqit (1.0.6-1) trusty; urgency=low
-
-  * Added missing code for config directories
-
- -- Jonathan Loh <joloh@ensoft.co.uk> Thurs, 15 Nov 2018 15:30:00 +0100
-
 tiqit (1.0.5-1) trusty; urgency=low
 
   * Fixes to the make_deb script.
@@ -15,8 +9,9 @@ tiqit (1.0.5-1) trusty; urgency=low
   * Set attachment titles to filenames by default.
   * Stop logical operators being changed when removing entries from
     a compound search.
+  * Added missing code for config directories
 
- -- Jonathan Loh <joloh@ensoft.co.uk> Wed, 4 Jul 2018 15:30:00 +0100
+ -- Jonathan Loh <joloh@ensoft.co.uk> Thurs, 15 Nov 2018 15:30:00 +0100
 
 tiqit (1.0.4-1) trusty; urgency=low
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ tiqit (1.0.5-1) trusty; urgency=low
   * Fixes to the make_deb script.
   * Gracefully handle searches updating between 0 and 1 results.
   * Sort search fields by display name, rather than internal name.
+  * Reset all forms on the bug page with the reset button.
   * Don't clear the search box when changing condition from is to is not.
   * Set attachment titles to filenames by default.
   * Stop logical operators being changed when removing entries from

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
 tiqit (1.0.5-1) trusty; urgency=low
 
   * Fixes to the make_deb script.
+  * Gracefully handle searches updating between 0 and 1 results.
 
- -- Jonathan Loh <joloh@ensoft.co.uk>  Fri, 24 Mar 2017 13:10:00 +0100
+ -- Jonathan Loh <joloh@ensoft.co.uk> Wed, 4 Jul 2018 15:30:00 +0100
 
 tiqit (1.0.4-1) trusty; urgency=low
 

--- a/make_deb
+++ b/make_deb
@@ -10,6 +10,14 @@ mkdir_or_die() {
     mkdir -p "$1" || die "Couldn't make directory '$0'"
 }
 
+fakeroot_state_first() {
+    # This should only be called once, as the first call to fakeroot.
+    # This will not expect $FAKEROOT_STATE to exist, and should
+    # prevent the first error message from appearing.
+    fakeroot -s "$FAKEROOT_STATE" $@
+}
+
+
 fakeroot_state() {
     fakeroot -i "$FAKEROOT_STATE" -s "$FAKEROOT_STATE" $@
 }
@@ -88,7 +96,7 @@ cp static/images/*.{png,svg,gif} "$MAIN_DIR/static/images"
 cp static/styles/*.css "$MAIN_DIR/static/styles"
 cp .htaccess "$MAIN_DIR"
 cp api/{.htaccess,api.py} "$MAIN_DIR/api"
-fakeroot_state chmod -R a-x,u=rw,go=r "$MAIN_DIR"
+fakeroot_state_first chmod -R a-x,u=rw,go=r "$MAIN_DIR"
 fakeroot_state chmod a+x "$MAIN_DIR/scripts/index.py"
 fakeroot_state chmod a+x "$MAIN_DIR/api/api.py"
 
@@ -115,7 +123,18 @@ fakeroot_state chmod -R a+X "$PACKAGE_DIR"
 # Make .deb metadata files
 # http://www.debian.org/doc/manuals/maint-guide/dreq.en.html
 # http://www.debian.org/doc/manuals/maint-guide/dother.en.html
-cp debian/control "$DEBIAN_DIR/control"
+cat << EOF >  "$DEBIAN_DIR/control"
+Package: tiqit
+Version: $PACKAGE_VERSION
+Section: misc
+Priority: optional
+Architecture: all
+Depends: python (>=2.6.5-0ubuntu1)
+Maintainer: Tiqit developers at Ensoft <tiqit@ensoft.co.uk>
+Description: The Intelligent Issue Tracker
+ A Bug Tracker with a twist. Focuses on user experience and flexibility,
+ adapting to the needs of the project.
+EOF
 
 cat <<EOF > "$DEBIAN_DIR/conffiles"
 /etc/tiqit/tiqit.conf

--- a/scripts/actions/addfile.py
+++ b/scripts/actions/addfile.py
@@ -9,6 +9,8 @@ args = Arguments()
 # Get a temporary file to put the attachment into
 filename = args.writeToTempFile('theFile')
 
+queueMessage(MSG_WARNING, "Filename: '{}'".format(args['fileTitle']))
+
 try:
     addAttachment(args['bugid'], args['fileTitle'], filename)
 

--- a/scripts/pages/view.py
+++ b/scripts/pages/view.py
@@ -324,14 +324,14 @@ def displayNotes(hide=False):
  <form action='addfile.py' method='post' enctype='multipart/form-data'>
   <input type='hidden' name='bugid' value='%s'>
   <p>
-   Title: <input name='fileTitle' type='text' size='50'>
+   Title: <input id='fileTitle' name='fileTitle' type='text' size='50' value="" onchange='unsetDefault()'>
 <!--
    Type: <select name='fileType'>
     <option value='Auto'>Auto</option>
     <option value='Text'>Text</option>
    </select>
 -->
-   <input type='file' name='theFile' size='30'>
+   <input type='file' id='theFile' name='theFile' size='30' onchange='updateFileName()'>
   </p>
   <p>
    <input type='submit' value='Save'>

--- a/scripts/pages/view.py
+++ b/scripts/pages/view.py
@@ -346,168 +346,129 @@ def displayNotes(hide=False):
 #
 # Histogram section
 #
+def displayGraph(status, numstates, changes, value, printCurrent=True, endtime=None, showTags=False, overrideBackground=True):
+    # Date range goes from Submitted-on until now by default
+    starttime = time.mktime(time.strptime(args['Submitted-onRaw'],
+                                          "%m/%d/%Y %H:%M:%S"))
+    nowtime = time.mktime(time.localtime())
+    if endtime is None:
+        endtime = nowtime
+    totaltime = endtime - starttime
+
+    print "<p>{}:</p>".format(status)
+    print "<div class='tiqitGraph' style='height: %dem'>" % (numstates + 1)
+    print "<div class='header'>"
+    # Print row headers
+    for i in range(len(changes)):
+        if showTags:
+            print "<div class='row' style='top: %dem;'>%s -&gt; %s</div>" % \
+                  (i, changes[i]['OldValue'], changes[i]['NewValue'])
+        else:
+            print "<div class='row' style='top: %dem;'><!--%s -&gt; %s --></div>" % \
+                  (i, changes[i]['OldValue'], changes[i]['NewValue'])
+
+    # Bonus row header for current value if required
+    if printCurrent:
+        i += 1
+        if showTags:
+            print "<div class='row' style='top: %dem;'>%s -&gt;</div>" % (i, value)
+        else:
+            print "<div class='row' style='top: %dem;'><!--%s -&gt;--></div>" % (i, value)
+
+    print "</div>"
+    print "<div class='graph' style='height: %dem'>" % numstates
+    sofar = 0
+    width = 0
+    currtime = starttime
+    for i in range(len(changes)):
+        width = (changes[i]['DateVal'] - currtime) / totaltime * 100
+        if overrideBackground:
+            print "<div title='Changed by %s' class='row %s' style='text-align: center; background-color: %s; top: %dem; left: %.2f%%; width: %.2f%%;'>%s</div>" % (changes[i]['User'], changes[i]['OldValue'], stringToColour(changes[i]['OldValue']), i, sofar, width, changes[i]['OldValue'])
+        else:
+            print "<div title='Changed by %s' class='row %s' style='top: %dem; left: %.2f%%; width: %.2f%%;'>%s</div>" % (changes[i]['User'], changes[i]['OldValue'], i, sofar, width, changes[i]['OldValue'])
+        currtime = changes[i]['DateVal']
+        sofar += width
+
+    # if required, print current value line
+    if printCurrent:
+        i += 1
+        width = (endtime - currtime) / totaltime * 100
+        if overrideBackground:
+            print "<div title='Currently %s' class='row %s' style='text-align: center; background-color: %s; top: %dem; left: %.2f%%; width: %.2f%%;'>%s</div>" % (value, value, stringToColour(value), i, sofar, width, value)
+        else:
+            print "<div title='Currently %s' class='row %s' style='top: %dem; left: %.2f%%; width: %.2f%%;'>%s</div>" % (value, value, i, sofar, width, value)
+
+    # Print a scale for the graph
+    section = (endtime - starttime) / 5
+    for s in range(6):
+        thistime = starttime + s * section
+        print "<div class='ruleline' style='left: %d%%'></div>" % (s * 20)
+        print "<div class='row scale' style='top: %dem; left: %d%%'>%s</div>" % (i + 1, s * 20, time.strftime("%d/%m/%Y", time.localtime(thistime)))
+
+    print "</div>"
+    print "</div>"
 
 def displayGraphs(hide=False):
     printSectionHeader("Graphs", hide=hide)
-
-    # Date range goes from Submitted-on until now
-    starttime = time.mktime(time.strptime(args['Submitted-onRaw'],
-                                          "%m/%d/%Y %H:%M:%S"))
-    endtime = time.mktime(time.localtime())
-    nowtime = endtime
-    totaltime = endtime - starttime
 
     # Go through history, looking for 'Status' changes
     statusChanges = [x for x in auditargs if x['Field'] == 'Status']
     statusChanges.reverse()
 
-    numstates = len(statusChanges)
-
-    # Unless current state is 'closed' in which case until last transition
-    if statusChanges and \
-       statusChanges[-1]['NewValue'] in ('R', 'V', 'C', 'D', 'J'):
-        endtime = statusChanges[-1]['DateVal']
-        totaltime = endtime - starttime
-        print "<p>Graphs cover %d days and are now closed.</p>" % \
-              (totaltime / 60 / 60 / 24)
-    else:
-        numstates += 1
-        print "<p>Graphs cover %d days and counting.</p>" % \
-              (totaltime / 60 / 60 / 24)
-
-    state = args['StatusRaw']
-    if statusChanges:
-        print "<p>Status:</p>"
-        print "<div class='tiqitGraph' style='height: %dem'>" % (numstates + 1)
-        print "<div class='header'>"
-        # Print row headers
-        for i in range(len(statusChanges)):
-            print "<div class='row' style='top: %dem;'>%s -&gt; %s</div>" % \
-                  (i, statusChanges[i]['OldValue'], statusChanges[i]['NewValue'])
-        # Bonus row header for current state if required
-        if endtime == nowtime:
-            i += 1
-            print "<div class='row' style='top: %dem;'>%s -&gt;</div>" % (i, state)
-        print "</div>"
-        print "<div class='graph' style='height: %dem'>" % numstates
-        sofar = 0
-        width = 0
-        currtime = starttime
-        for i in range(len(statusChanges)):
-            width = (statusChanges[i]['DateVal'] - currtime) / totaltime * 100
-            print "<div title='Changed by %s' class='row %s' style='top: %dem; left: %.2f%%; width: %.2f%%;'>%s</div>" % (statusChanges[i]['User'], statusChanges[i]['OldValue'], i, sofar, width, statusChanges[i]['OldValue'])
-            currtime = statusChanges[i]['DateVal']
-            sofar += width
-
-        # if required, print current state line
-        if nowtime == endtime:
-            i += 1
-            width = (endtime - currtime) / totaltime * 100
-            print "<div title='Currently %s' class='row %s' style='top: %dem; left: %.2f%%; width: %.2f%%;'>%s</div>" % (state, state, i, sofar, width, state)
-
-        # Print a scale for the graph
-        section = (endtime - starttime) / 5
-        for s in range(6):
-            thistime = starttime + s * section
-            print "<div class='ruleline' style='left: %d%%'></div>" % (s * 20)
-            print "<div class='row scale' style='top: %dem; left: %d%%'>%s</div>" % (i + 1, s * 20, time.strftime("%d/%m/%Y", time.localtime(thistime)))
-        
-        print "</div>"
-        print "</div>"
-    else:
-        print "<p><img src='images/warning-small.png' alt='/!\\'> No status history available.</p>"
-
     # Go through history, looking for 'Component' changes
     compChanges = [x for x in auditargs if x['Field'] == 'Component']
     compChanges.reverse()
-
-    numchanges = len(compChanges) + 1
-
-    comp = args['ComponentRaw']
-    if compChanges:
-        print "<p>Component:</p>"
-        print "<div class='tiqitGraph' style='height: %dem'>" % (numstates + 1)
-        print "<div class='header'>"
-        # Print row headers
-        for i in range(len(compChanges)):
-            print "<div class='row' style='top: %dem;'><!--%s -&gt; %s--></div>" % \
-                  (i, compChanges[i]['OldValue'], compChanges[i]['NewValue'])
-        # Bonus row header for current state
-        i += 1
-        print "<div class='row' style='top: %dem;'><!--%s -&gt;--></div>" % (i, comp)
-        print "</div>"
-        print "<div class='graph' style='height: %dem'>" % numchanges
-        sofar = 0
-        width = 0
-        currtime = starttime
-        for i in range(len(compChanges)):
-            width = (compChanges[i]['DateVal'] - currtime) / totaltime * 100
-            print "<div title='Changed by %s' class='row' style='text-align: center; background-color: %s; top: %dem; left: %.2f%%; width: %.2f%%;'>%s</div>" % (compChanges[i]['User'], stringToColour(compChanges[i]['OldValue']), i, sofar, width, compChanges[i]['OldValue'])
-            currtime = compChanges[i]['DateVal']
-            sofar += width
-
-        # print current comp line
-        i += 1
-        width = (endtime - currtime) / totaltime * 100
-        print "<div title='Currently %s' class='row' style='text-align: center; background-color: %s; top: %dem; left: %.2f%%; width: %.2f%%;'>%s</div>" % (comp, stringToColour(comp), i, sofar, width, comp)
-
-        # Print a scale for the graph
-        section = (endtime - starttime) / 5
-        for s in range(6):
-            thistime = starttime + s * section
-            print "<div class='ruleline' style='left: %d%%'></div>" % (s * 20)
-            print "<div class='row scale' style='top: %dem; left: %d%%'>%s</div>" % (i + 1, s * 20, time.strftime("%d/%m/%Y", time.localtime(thistime)))
-        
-        print "</div>"
-        print "</div>"
-    else:
-        print "<p><img src='images/warning-small.png' alt='/!\\'> No component history available.</p>"
 
     # Go through history, looking for 'Severity' changes
     sevChanges = [x for x in auditargs if x['Field'] == 'Severity-desc']
     sevChanges.reverse()
 
-    numchanges = len(sevChanges) + 1
+    starttime = time.mktime(time.strptime(args['Submitted-onRaw'],
+                                          "%m/%d/%Y %H:%M:%S"))
+    nowtime = time.mktime(time.localtime())
+    endtime = nowtime
+    # Unless current state is 'closed' in which case until last transition
+    if statusChanges and \
+       statusChanges[-1]['NewValue'] in ('R', 'V', 'C', 'D', 'J'):
+        endtimes = list()
+        if statusChanges:
+            endtimes.append(statusChanges[-1]['DateVal'])
+        if compChanges:
+            endtimes.append(compChanges[-1]['DateVal'])
+        if sevChanges:
+            endtimes.append(sevChanges[-1]['DateVal'])
+        endtimes.sort()
 
-    sev = args['SeverityRaw']
+        # Get the latest endtime
+        if endtimes:
+            endtime = endtimes[-1]
+        totaltime = endtime - starttime
+        print "<p>Graphs cover %d days and are now closed.</p>" % \
+              (totaltime / 60 / 60 / 24)
+    else:
+        totaltime = endtime - starttime
+        print "<p>Graphs cover %d days and counting.</p>" % \
+              (totaltime / 60 / 60 / 24)
+
+    # Draw status graph
+    if statusChanges:
+        # Only print the last column if the endtime is not the time of the
+        # last status change
+        printCurrent = (endtime != statusChanges[-1]['DateVal'])
+        displayGraph("Status", len(statusChanges) + int(printCurrent), statusChanges, args['StatusRaw'],
+                     printCurrent=printCurrent, endtime=endtime, showTags=True, overrideBackground=False)
+    else:
+        print "<p><img src='images/warning-small.png' alt='/!\\'> No status history available.</p>"
+
+    # Draw component graph
+    if compChanges:
+        displayGraph("Component", len(compChanges) + 1, compChanges, args['ComponentRaw'], endtime=endtime)
+    else:
+        print "<p><img src='images/warning-small.png' alt='/!\\'> No component history available.</p>"
+
+    # Draw severity graph
     if sevChanges:
-        print "<p>Severity:</p>"
-        print "<div class='tiqitGraph' style='height: %dem'>" % (numchanges + 1)
-        print "<div class='header'>"
-        # Print row headers
-        for i, change in enumerate(sevChanges):
-            print "<div class='row' style='top: %dem;'>%s -&gt; %s</div>" % \
-                  (i, change['OldValue'], change['NewValue'])
-        # Bonus row header for current state if required
-        if endtime == nowtime:
-            i += 1
-            print "<div class='row' style='top: %dem;'>%s -&gt;</div>" % (i, sev)
-        print "</div>"
-        print "<div class='graph' style='height: %dem'>" % numchanges
-        sofar = 0
-        width = 0
-        currtime = starttime
-        for i, change in enumerate(sevChanges):
-            width = (change['DateVal'] - currtime) / totaltime * 100
-            print "<div title='Changed by %s' class='row' style='text-align: center; background-color: %s; top: %dem; left: %.2f%%; width: %.2f%%;'>%s</div>" % (change['User'], stringToColour(change['OldValue']), i, sofar, width, change['OldValue'])
-            currtime = change['DateVal']
-            sofar += width
-
-        # if required, print current state line
-        if nowtime == endtime:
-            i += 1
-            width = (endtime - currtime) / totaltime * 100
-            print "<div title='Currently %s' class='row' style='text-align: center; background-color: %s; top: %dem; left: %.2f%%; width: %.2f%%;'>%s</div>" % (sev, stringToColour(sev), i, sofar, width, sev)
-
-        # Print a scale for the graph
-        section = (endtime - starttime) / 5
-        for s in range(6):
-            thistime = starttime + s * section
-            print "<div class='ruleline' style='left: %d%%'></div>" % (s * 20)
-            print "<div class='row scale' style='top: %dem; left: %d%%'>%s</div>" % (i + 1, s * 20, time.strftime("%d/%m/%Y", time.localtime(thistime)))
-        
-        print "</div>"
-        print "</div>"
+        displayGraph("Severity", len(sevChanges) + 1, sevChanges, args['SeverityRaw'], endtime=endtime)
     else:
         print "<p><img src='images/warning-small.png' alt='/!\\'> No severity history available.</p>"
 
@@ -588,7 +549,7 @@ def displayRelates(hide=False):
         bad = args['Previous-commit-idRaw']
         if bad:
             relates.append((bad, 'Bad Code Fix for', False))
-      
+
     # Now we have all the relates. Get their data, so we can print a nice table
     printSectionHeader('Relates', 'Related Bugs', hide=hide)
 

--- a/scripts/pages/view.py
+++ b/scripts/pages/view.py
@@ -230,7 +230,7 @@ def displayGeneral(hide=False):
 <div id='extraCopies'></div>
 <p>
  <input type='submit' value='Save Changes'>
- <input type='button' value='Reset Form' onclick='this.form.reset(); checkChildren(); checkFormValidity();'>
+ <input type='button' value='Reset Form' onclick='resetForm();'>
  <input type='button' onclick='if (!amEditing || confirm("You&apos;ve made changes to this bug. Cloning it will throw them away. Are you sure you want to continue?")) document.location = "newbug.py?bugid=%(Identifier)s";' value='Clone Bug'>
 </p>
 </form>""" % args

--- a/scripts/tiqit/__init__.py
+++ b/scripts/tiqit/__init__.py
@@ -32,6 +32,7 @@ __all__ = [
     'SITE_MAIN', 'SITE_META',
     'database', 'initialise',
     'errorPage',
+    'CFG_DIRS',
 ]
 
 times = [("start", time.time())]
@@ -44,7 +45,7 @@ times = [("start", time.time())]
 
 MAJ_VER   = 1
 MIN_VER   = 0
-PATCH_VER = 5
+PATCH_VER = 6
 DEV_VER   = 1
 
 VERSION = (MAJ_VER, MIN_VER, PATCH_VER)
@@ -312,6 +313,8 @@ if not DATA_PATH.endswith('/'):
     DATA_PATH = DATA_PATH + '/'
 PROFILE_PATH = DATA_PATH + 'profiles/'
 NEWS_PATH    = DATA_PATH + 'news/'
+CFG_DIRS = ["../",
+            "/etc/tiqit/"]
 
 
 #

--- a/scripts/tiqit/__init__.py
+++ b/scripts/tiqit/__init__.py
@@ -45,8 +45,8 @@ times = [("start", time.time())]
 
 MAJ_VER   = 1
 MIN_VER   = 0
-PATCH_VER = 6
-DEV_VER   = 1
+PATCH_VER = 5
+DEV_VER   = 0
 
 VERSION = (MAJ_VER, MIN_VER, PATCH_VER)
 VERSION_STRING = '.'.join(map(str, VERSION)) + (DEV_VER < 0 and "b%d" % -DEV_VER or "")

--- a/scripts/tiqit/__init__.py
+++ b/scripts/tiqit/__init__.py
@@ -44,8 +44,8 @@ times = [("start", time.time())]
 
 MAJ_VER   = 1
 MIN_VER   = 0
-PATCH_VER = 4
-DEV_VER   = 0
+PATCH_VER = 5
+DEV_VER   = 1
 
 VERSION = (MAJ_VER, MIN_VER, PATCH_VER)
 VERSION_STRING = '.'.join(map(str, VERSION)) + (DEV_VER < 0 and "b%d" % -DEV_VER or "")

--- a/static/scripts/filter.js
+++ b/static/scripts/filter.js
@@ -476,6 +476,10 @@ function tiqitFilterTable(tableName, filterFunc, prepFunc) {
 
     for (var j = 0; j < tables[i].tBodies.length; j++) {
       for (var k = 0; k < tables[i].tBodies[j].rows.length; k++) {
+        if (tables[i].tBodies[j].rows[k].id == tableName + 'TablePlaceholderRow'
+            || tables[i].tBodies[j].rows[k].isRemoved) {
+          continue;
+        }
         show = filterFunc(tables[i].tBodies[j].rows[k], filter);
 
         total++;

--- a/static/scripts/search.js
+++ b/static/scripts/search.js
@@ -538,10 +538,16 @@ function addRow(event) {
         }
     }
 
-    // If the row above doesn't have its Op, then put our Op where its Op is.
+    // If the row above doesn't have its Op, then put our Op where its Op is and give it back its Op
     var theOp = document.getElementById('operation' + (num - 1));
     var theP = document.getElementById('row' + (num - 1));
     if (theOp && theOp.parentNode != theP) {
+        // Swap the select values
+        var theSelectValue = theOp.getElementsByTagName('select')[0].value;
+        theOp.getElementsByTagName('select')[0].value = newOp.getElementsByTagName('select')[0].value;
+        newOp.getElementsByTagName('select')[0].value = theSelectValue;
+
+        // Position the ops
         theOp.parentNode.appendChild(newOp);
         newOp.setLevel(theOp.getElementsByTagName('input')[0].value);
         theP.appendChild(theOp);
@@ -608,6 +614,13 @@ function removeRow() {
     var theOp = document.getElementById('operation' + num);
     if (theOp) {
         var oldOp = document.getElementById('operation' + (num - 1));
+
+        // Swap the select values
+        var theSelectValue = theOp.getElementsByTagName('select')[0].value;
+        theOp.getElementsByTagName('select')[0].value = oldOp.getElementsByTagName('select')[0].value;
+        oldOp.getElementsByTagName('select')[0].value = theSelectValue;
+
+        // Reposition the Op
         theOp.parentNode.appendChild(oldOp);
         oldOp.setLevel(theOp.getElementsByTagName('input')[0].value);
         theOp.parentNode.removeChild(theOp);

--- a/static/scripts/search.js
+++ b/static/scripts/search.js
@@ -289,6 +289,14 @@ function createFieldPicker(num) {
     newF.setAttribute('name', 'field' + num);
     newF.onchange = updateRels;
 
+    // Sort fields by their display names rather than their internal names
+    allSearchableFields.sort(
+      function(a, b) {
+        return allFields[a].longname.toLowerCase().localeCompare(
+                 allFields[b].longname.toLowerCase());
+      }
+    );
+
     for (var i in allSearchableFields) {
         opt = document.createElement('option');
         opt.setAttribute('value', allSearchableFields[i]);

--- a/static/scripts/search.js
+++ b/static/scripts/search.js
@@ -258,8 +258,8 @@ function updateVals(field, num) {
   var oldVal = document.getElementById('val' + num);
 
   // Save the contents if they are both text fields
-  if (vals.type == 'text' && oldVal.type == 'text') {
-    vals.value = oldVal.value;
+  if (vals.input.type == 'text' && oldVal.input.type == 'text') {
+    vals.input.value = oldVal.input.value;
   }
 
   oldVal.parentNode.replaceChild(vals, oldVal);

--- a/static/scripts/selectfield.js
+++ b/static/scripts/selectfield.js
@@ -44,6 +44,15 @@ function createFieldSelector(name, num) {
   newS.setAttribute('id', name + num);
   newS.setAttribute('name', name + num);
   newS.addEventListener('change', Tiqit.search.checkGroupBy, false);
+
+  // Sorts fields by their display names, instead of internal names
+  allViewableFields.sort(
+    function(a, b) {
+      return allFields[a].longname.toLowerCase().localeCompare(
+               allFields[b].longname.toLowerCase());
+    }
+  );
+
   for (f in allViewableFields) {
     opt = document.createElement('option');
     opt.setAttribute('value', allViewableFields[f]);

--- a/static/scripts/updateresults.js
+++ b/static/scripts/updateresults.js
@@ -427,21 +427,19 @@ function processUpdatedBugList(bugs) {
       // table.
       var cell, span;
 
-      // Special case: if there were no bugs to start with, there will be
-      // no tables! Create one here
-      if (tables.length == 0) {
-        tables.push(document.createElement('table'));
-        tables[0].id = 'results';
-        tables[0].appendChild(document.createElement('thead'));
-        tables[0].appendChild(document.createElement('tbody'));
-        tables[0].tHead.insertRow(-1);
-        for (var j = 0; j < fields.length; j++) {
-          cell = document.createElement('th');
-          tables[0].tHead.rows[0].appendChild(cell);
+      // If there were no bugs previously then the table will have a placeholder
+      // row to ensure the table is still rendered. This placeholder is no
+      // longer needed as we now have bugs to show
+      // If the table contains a placeholder row, delete it
+      var placeholder = document.getElementById("resultsTablePlaceholderRow")
+      if (placeholder) {
+        placeholder.parentNode.removeChild(placeholder);
+      }
 
-          cell.appendChild(document.createTextNode(fields[j].getAttribute('name')));
-        }
-        document.getElementById('tiqitContent').appendChild(tables[0]);
+      // Similarly, remove the no results warning if it exists
+      var pNoResWarn = document.getElementById("noResultsWarning")
+      if (pNoResWarn) {
+          pNoResWarn.remove();
       }
 
       var row = tables[0].tBodies[0].insertRow(-1);

--- a/static/scripts/view.js
+++ b/static/scripts/view.js
@@ -520,6 +520,19 @@ function getFieldValueView(field) {
     }
 }
 
+function resetForm() {
+    // Want to reset both initial form and extras form.
+    document.getElementById("tiqitBugEdit").reset();
+    document.getElementById("tiqitExtraFormData").reset();
+
+    // Also clear the indicator on the Component name if it has been set - 
+    // not being reset in checkFormValidity().
+    element = document.getElementById("Component");
+    Tiqit.clearIndicator(element);
+
+    checkChildren();
+    checkFormValidity();
+}
 
 function checkChildren() {
     var ev = new Object();

--- a/static/scripts/view.js
+++ b/static/scripts/view.js
@@ -842,3 +842,26 @@ function prepareForm() {
   else
     return true;
 }
+
+//
+// Update the default file name when a file is entered
+//
+var default_being_used = true;
+
+function updateFileName() {
+  var encTitle = document.getElementById("fileTitle");
+  var fileInput = document.getElementById("theFile");
+
+  var fileName = fileInput.files.item(0).name.split('.', 1)[0];
+
+  //window.alert(fileName);
+
+  if (encTitle.value == "" || default_being_used) {
+      encTitle.value = fileName;
+      default_being_used = true;
+  }
+}
+
+function unsetDefault() {
+    default_being_used = false;
+}


### PR DESCRIPTION
Recent updates to Tiqit.

  * Fixes to the make_deb script.
  * Gracefully handle searches updating between 0 and 1 results.
  * Sort search fields by display name, rather than internal name.
  * Stop severity graph overflow.
  * Reset all forms on the bug page with the reset button.
  * Don't clear the search box when changing condition from is to is not.
  * Set attachment titles to filenames by default.
  * Stop logical operators being changed when removing entries from
a compound search.
 * Add in config directories

