### PR TITLE
cgitb emits HTML comments in the section reserved for HTTP headers

### DIFF
--- a/scripts/index.py
+++ b/scripts/index.py
@@ -23,7 +23,10 @@
 
 # Pretty stack traces but with 500 status codes
 import cgitb, sys
+
 def excHandler(*args):
+    print "Content-Type: text/html; charset=utf-8"
+    print "\r\n\r\n"
     print "<!--: spam"
     print "Status: 500"
     cgitb.handler(args)


### PR DESCRIPTION
Per [this StackOverflow post](https://serverfault.com/questions/853103/500-internal-server-ah02429-response-header-name) and some investigation, we were printing HTML comments in the section reserved for HTTP headers (everything before \r\n\r\n). This is also true of the base cgitb handler.

I added the Content-Type HTTP header so that we can view tracebacks in the browser reliably (it was being interpreted as a Python file otherwise, though this might be due to my Apache config).