### PR TITLE
Fix operators all switching to AND during query loading/modification

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+tiqit (1.0.8-1) trusty; urgency=low
+
+  * Fix query operators switching from OR to AND when returning to modify an
+    existing query.
+
+ -- Olli Johnson <ollijohnson93@gmail.com>  Wed, 25 Mar 2020 17:50:00 +0000
+
 tiqit (1.0.7-1) trusty; urgency=low
 
   * Fix cookie parsing when cookie string includes cookies without "="

--- a/scripts/pages/search.py
+++ b/scripts/pages/search.py
@@ -32,7 +32,7 @@ loadSavedSearch()
 args = Arguments()
 
 initSearch = ["Tiqit.search.rowsAdded = false;"]
-initSearch.append("function init() {");
+initSearch.append("function init() {")
 
 initSearch.append("""
 showSection("Searcher", true);
@@ -46,21 +46,23 @@ prefs = loadPrefs()
 
 #
 # The algorithm for regenerating a query is this:
-# - add a new row
-# - set values of new row
-# - move the row all the way to level 0
-# - move the row up to the correct level (a full set of opening brackets above it now)
-# - move the opening brackets above it to their correct level.
+# 1. Construct the format query. For each row:
+#   - add a new row
+#   - move the row all the way to level 0
+#   - move the row up to the correct level (a full set of opening brackets above it now)
+#   - move the opening brackets above it to their correct level.
+# 2. Set the content of the query. For each row:
+#   - set values of new row
+#
+# This two stage approach is required to ensure the values of query fields
+# and operators are not modified by the restructuring of the query format, so
+# they are set afterwards when all structure modifications are complete.
 #
 i = 1
 level = 0
 initSearch.append("if (!Tiqit.search.rowsAdded) {");
 while args.has_key('field%d' % i):
     initSearch.append("Tiqit.search.addRow(document.getElementById('adder' + %d));" % (i - 1))
-    initSearch.append("Tiqit.search.setRowValues(%d, '%s', '%s', '%s', '%s');" \
-          % (i, args['field%d' % i], args['rel%d' % i], args['val%d' % i],
-             args['operation%d' % i]))
-
     # Move in to level 0
     while level > 0:
         initSearch.append("Tiqit.search.shiftLeft(document.getElementById('leftShifter' + %d));" % i)
@@ -79,8 +81,16 @@ while args.has_key('field%d' % i):
         while bracketLevel <= targetLevel:
             initSearch.append("Tiqit.search.bracketRightShift(document.getElementById('openBracket%d.%d').childNodes[1]);" % (i, bracketLevel))
             bracketLevel += 1
-        
+
     i += 1
+
+i = 1
+while args.has_key('field%d' % i):
+    initSearch.append("Tiqit.search.setRowValues(%d, '%s', '%s', '%s', '%s');" \
+          % (i, args['field%d' % i], args['rel%d' % i], args['val%d' % i],
+             args['operation%d' % i]))
+    i += 1
+
 
 if i == 1:
     if not args.has_key('modify'):

--- a/scripts/pages/search.py
+++ b/scripts/pages/search.py
@@ -81,7 +81,6 @@ while args.has_key('field%d' % i):
         while bracketLevel <= targetLevel:
             initSearch.append("Tiqit.search.bracketRightShift(document.getElementById('openBracket%d.%d').childNodes[1]);" % (i, bracketLevel))
             bracketLevel += 1
-
     i += 1
 
 i = 1
@@ -90,7 +89,6 @@ while args.has_key('field%d' % i):
           % (i, args['field%d' % i], args['rel%d' % i], args['val%d' % i],
              args['operation%d' % i]))
     i += 1
-
 
 if i == 1:
     if not args.has_key('modify'):

--- a/scripts/tiqit/__init__.py
+++ b/scripts/tiqit/__init__.py
@@ -45,7 +45,7 @@ times = [("start", time.time())]
 
 MAJ_VER   = 1
 MIN_VER   = 0
-PATCH_VER = 7
+PATCH_VER = 8
 DEV_VER   = 0
 
 VERSION = (MAJ_VER, MIN_VER, PATCH_VER)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from distutils.core import setup
 
 setup(name='tiqit',
-      version="1.0.7",
+      version="1.0.8",
       description='Tiqit: The Intelligent Issue Tracker',
       url='https://launchpad.net/tiqit',
       maintainer='Tiqit maintainers at Ensoft',


### PR DESCRIPTION
Tested loading searches through "modify" button and by manual URL editing.
Tested with variety of query layouts with and without braces and nesting.
Confirmed that other search construction behaviour not impacted.
