### PR TITLE
Fix search relationships getting cleared when editing dropdowns

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ tiqit (1.0.10-1) trusty; urgency=low
   * Empty the "update" cookie to prevent alerts persisting unnecessarily.
   * Add support for new field types.
   * Fix adding dot-files creating attachments with empty names.
+  * Fix relationships getting cleared when editing search query types.
 
  -- Jonathan Loh <Joloh@cisco.com> Wed, 14 August 2020 13:02:02 +0000
 

--- a/static/scripts/search.js
+++ b/static/scripts/search.js
@@ -320,17 +320,19 @@ function createRelPicker(num, field) {
     newRel.setAttribute('id', 'rel' + num);
     newRel.setAttribute('name', 'rel' + num);
 
+    var allowedValues = [];
     for (var i in allFields[field].rels) {
         opt = document.createElement('option');
         opt.setAttribute('value', allFields[field].rels[i][1]);
         opt.appendChild(document.createTextNode(allFields[field].rels[i][0]));
+        allowedValues.push(allFields[field].rels[i][1]);
 
         newRel.appendChild(opt);
     }
 
     // If being added after an existing entry, copy that entries value
     var previousRel = document.getElementById('rel' + (num - 1));
-    if (previousRel) {
+    if (previousRel && allowedValues.includes(previousRel.value)) {
         newRel.value = previousRel.value;
     }
 


### PR DESCRIPTION
Tested by modify search query rows to different field types and confirming the default relationship is used where as before the relationship was being cleared.