### PR TITLE
Fix issue where dotfiles leave the filetitle field blank when adding file attachments

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ tiqit (1.0.10-1) trusty; urgency=low
 
   * Empty the "update" cookie to prevent alerts persisting unnecessarily.
   * Add support for new field types.
+  * Fix adding dot-files creating attachments with empty names.
 
  -- Jonathan Loh <Joloh@cisco.com> Wed, 14 August 2020 13:02:02 +0000
 

--- a/static/scripts/view.js
+++ b/static/scripts/view.js
@@ -865,7 +865,7 @@ function updateFileName() {
   var encTitle = document.getElementById("fileTitle");
   var fileInput = document.getElementById("theFile");
 
-  var fileName = fileInput.files.item(0).name.split('.', 1)[0];
+  var fileName = fileInput.files.item(0).name.replace(/^\./g, '').split('.', 1)[0];
 
   //window.alert(fileName);
 

--- a/static/scripts/view.js
+++ b/static/scripts/view.js
@@ -865,7 +865,7 @@ function updateFileName() {
   var encTitle = document.getElementById("fileTitle");
   var fileInput = document.getElementById("theFile");
 
-  var fileName = fileInput.files.item(0).name.replace(/^\./g, '').split('.', 1)[0];
+  var fileName = fileInput.files.item(0).name.replace(/^\.+/g, '').split('.', 1)[0];
 
   //window.alert(fileName);
 


### PR DESCRIPTION
Tested by uploading files with file names starting with no, single and multiple leading dots. E.g. "foo.txt", ".bar", "...bazz" result in attachments with names "foo", "bar" and "bazz" respectively.