### PR TITLE
"update" cookie removal

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+tiqit (1.0.10-1) trusty; urgency=low
+
+  * Empty the "update" cookie to prevent alerts persisting unnecessarily.
+
+ -- Jonathan Loh <Joloh@cisco.com> Mon, 06 July 2020 18:02:02 +0000
+
 tiqit (1.0.9-1) trusty; urgency=low
 
   * Account for plugins which do not provide outgoing cookies.

--- a/scripts/tiqit/__init__.py
+++ b/scripts/tiqit/__init__.py
@@ -45,7 +45,7 @@ times = [("start", time.time())]
 
 MAJ_VER   = 1
 MIN_VER   = 0
-PATCH_VER = 9
+PATCH_VER = 10
 DEV_VER   = 0
 
 VERSION = (MAJ_VER, MIN_VER, PATCH_VER)

--- a/scripts/tiqit/__init__.py
+++ b/scripts/tiqit/__init__.py
@@ -1124,7 +1124,7 @@ def printPageHeader(pageName, pageTitle="", initScript=None, otherHeaders=[],
     if outgoingCookies:
         for c in outgoingCookies:
             print c
-        print "Set-Cookie: update=; expires=Sat, 01-Jan-2000 00:00:00 GMT; path=%s" % getBasePath()
+    print "Set-Cookie: update=; Max-Age=0; path=%s" % getBasePath()
     print "Content-Type: text/html; charset=utf-8"
     print """
 <html>

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from distutils.core import setup
 
 setup(name='tiqit',
-      version="1.0.9",
+      version="1.0.10",
       description='Tiqit: The Intelligent Issue Tracker',
       url='https://launchpad.net/tiqit',
       maintainer='Tiqit maintainers at Ensoft',


### PR DESCRIPTION
Tested on local instance. Prevents alerts from persisting. Able to repro by modifying a bug, and then moving to a different page (e.g. back to search). The alert "Successfully updated Bug."  no longer reappears even after the "!" has been clicked.