### PR TITLE
tiqit (1.0.10-1)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
 tiqit (1.0.10-1) trusty; urgency=low
 
+  * Empty the "update" cookie to prevent alerts persisting unnecessarily.
   * Add support for new field types.
 
  -- Jonathan Loh <Joloh@cisco.com> Wed, 14 August 2020 13:02:02 +0000

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ tiqit (1.0.10-1) trusty; urgency=low
 
   * Empty the "update" cookie to prevent alerts persisting unnecessarily.
   * Add support for new field types.
+  * Fix adding dot-files creating attachments with empty names.
 
  -- Jonathan Loh <Joloh@cisco.com> Wed, 14 August 2020 13:02:02 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+tiqit (1.0.10-1) trusty; urgency=low
+
+  * Add support for new field types.
+
+ -- Jonathan Loh <Joloh@cisco.com> Wed, 14 August 2020 13:02:02 +0000
+
 tiqit (1.0.9-1) trusty; urgency=low
 
   * Account for plugins which do not provide outgoing cookies.

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ tiqit (1.0.10-1) trusty; urgency=low
   * Empty the "update" cookie to prevent alerts persisting unnecessarily.
   * Add support for new field types.
   * Fix adding dot-files creating attachments with empty names.
+  * Fix relationships getting cleared when editing search query types.
 
  -- Jonathan Loh <Joloh@cisco.com> Wed, 14 August 2020 13:02:02 +0000
 

--- a/scripts/fields.py
+++ b/scripts/fields.py
@@ -18,7 +18,7 @@ __all__ = [
     "filterDisplayUser",
 ]
 
-TEXT_TYPES = ('Component', 'AcmeComponent', 'Text', 'Number', 'ForeignID')
+TEXT_TYPES = ('Component', 'AcmeComponent', 'Text', 'Number', 'ForeignID', 'Character', 'Varchar')
 
 # This function calculates the cross product of 2 lists of tuples to give
 # another list of tuples as per the following example:
@@ -187,7 +187,7 @@ class TiqitField(object):
         elif self.type == 'Boolean':
             self._filterEditableHtml = filterDisplayEditableCheckbox
         else:
-            raise KeyError, "Unknown field type %s (type is %s)" % (self.name, self.type)
+            raise KeyError, "Unknown field type for field '%s' (type is %s)" % (self.name, self.type)
 
     def _getSaveName(self):
         return self.viewnames[0]

--- a/scripts/tiqit/__init__.py
+++ b/scripts/tiqit/__init__.py
@@ -45,7 +45,7 @@ times = [("start", time.time())]
 
 MAJ_VER   = 1
 MIN_VER   = 0
-PATCH_VER = 9
+PATCH_VER = 10
 DEV_VER   = 0
 
 VERSION = (MAJ_VER, MIN_VER, PATCH_VER)

--- a/scripts/tiqit/__init__.py
+++ b/scripts/tiqit/__init__.py
@@ -1124,7 +1124,7 @@ def printPageHeader(pageName, pageTitle="", initScript=None, otherHeaders=[],
     if outgoingCookies:
         for c in outgoingCookies:
             print c
-        print "Set-Cookie: update=; expires=Sat, 01-Jan-2000 00:00:00 GMT; path=%s" % getBasePath()
+    print "Set-Cookie: update=; Max-Age=0; path=%s" % getBasePath()
     print "Content-Type: text/html; charset=utf-8"
     print """
 <html>

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from distutils.core import setup
 
 setup(name='tiqit',
-      version="1.0.9",
+      version="1.0.10",
       description='Tiqit: The Intelligent Issue Tracker',
       url='https://launchpad.net/tiqit',
       maintainer='Tiqit maintainers at Ensoft',

--- a/static/scripts/fields.js
+++ b/static/scripts/fields.js
@@ -86,10 +86,10 @@ TiqitField = function(name, shortname, longname, ftype, maxlen, displaylen, req,
     } else if (this.ftype == 'Userid' && this.mvf) {
       this.rels = relUserMvf;
       this.values = null;
-    } else if (contains(['Text', 'Component', 'ForeignID'], this.ftype) && !this.mvf) {
+    } else if (contains(['Text', 'Component', 'ForeignID', 'Character', 'Varchar'], this.ftype) && !this.mvf) {
       this.rels = relText;
       this.values = null;
-    } else if (contains(['Text', 'Component', 'ForeignID'], this.ftype) && this.mvf) {
+    } else if (contains(['Text', 'Component', 'ForeignID', 'Character', 'Varchar'], this.ftype) && this.mvf) {
       this.rels = relTextMvf;
       this.values = null;
     } else if (this.ftype == 'Boolean') {

--- a/static/scripts/search.js
+++ b/static/scripts/search.js
@@ -320,17 +320,19 @@ function createRelPicker(num, field) {
     newRel.setAttribute('id', 'rel' + num);
     newRel.setAttribute('name', 'rel' + num);
 
+    var allowedValues = [];
     for (var i in allFields[field].rels) {
         opt = document.createElement('option');
         opt.setAttribute('value', allFields[field].rels[i][1]);
         opt.appendChild(document.createTextNode(allFields[field].rels[i][0]));
+        allowedValues.push(allFields[field].rels[i][1]);
 
         newRel.appendChild(opt);
     }
 
     // If being added after an existing entry, copy that entries value
     var previousRel = document.getElementById('rel' + (num - 1));
-    if (previousRel) {
+    if (previousRel && allowedValues.includes(previousRel.value)) {
         newRel.value = previousRel.value;
     }
 

--- a/static/scripts/view.js
+++ b/static/scripts/view.js
@@ -865,7 +865,7 @@ function updateFileName() {
   var encTitle = document.getElementById("fileTitle");
   var fileInput = document.getElementById("theFile");
 
-  var fileName = fileInput.files.item(0).name.split('.', 1)[0];
+  var fileName = fileInput.files.item(0).name.replace(/^\.+/g, '').split('.', 1)[0];
 
   //window.alert(fileName);
 


### PR DESCRIPTION
- Empty the "update" cookie to prevent alerts persisting unnecessarily.
- Add support for new field types.
- Fix adding dot-files creating attachments with empty names.
- Fix relationships getting cleared when editing search query types.