### PR TITLE
Initial work for adding a filterEdit call during multiedit

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+tiqit (1.0.11-1) trusty; urgency=high
+
+  * Use filterEdit functionality to convert modified fields into their
+    backend format during search result bug record modifications.
+
+ -- Jonathan Loh <Joloh@cisco.com> Wed, 14 August 2020 13:02:02 +0000
+
 tiqit (1.0.10-1) trusty; urgency=low
 
   * Empty the "update" cookie to prevent alerts persisting unnecessarily.

--- a/scripts/helpers/multiedit.py
+++ b/scripts/helpers/multiedit.py
@@ -10,7 +10,7 @@ from backend import *
 args = Arguments()
 
 #
-# First check for scribbling
+# First check for changes the user is not aware of.
 #
 data = loadBugs([args['Identifier']])[0]
 
@@ -25,38 +25,54 @@ if realupdate > lastupdate:
 
 else:
     #
-    # Now build up arguments
+    # Determine the changes the user has requested. Convert each change to
+    # its backend format.
     #
 
     fields = args['fields'].split(',')
     changes = {}
 
+    is_get_changes_success = True
     for f in fields:
-        # The value should be really filterEdited. This logic is missing and
-        # should be added to fix changing the inability to save Component
-        # on the multiedit page.
-        changes[allFields[f].savename] = args[f]
+        if not is_get_changes_success:
+            continue
 
-    try:
-        updateBug(args['Identifier'], changes)
+        try:
+            changes[allFields[f].savename] = allFields[f].filterEdit(args, args[f])
+        except Exception as err:
+            # There's an issue with the conversion to the backend format.
+            is_get_changes_success = False
+            queueMessage(MSG_ERROR,
+                         "Failed to save changes to {}. Unable to convert {} value '{}': {}".format(
+                             args['Identifier'], f, args[f], str(err)))
+            printXMLPageHeader(extraheaders=['Status: 500'])
+            printXMLMessages()
+            printXMLPageFooter()
 
-        data = loadBugs([args['Identifier']])[0]
+    if is_get_changes_success:
+        #
+        # Attempt to save the changes
+        #
+        try:
+            updateBug(args['Identifier'], changes)
 
-        printXMLPageHeader()
-        printXMLMessages()
-        printXMLSectionHeader("buglist")
-        print """
+            data = loadBugs([args['Identifier']])[0]
+
+            printXMLPageHeader()
+            printXMLMessages()
+            printXMLSectionHeader("buglist")
+            print """
   <bug identifier='%s' lastupdate='%s'>""" % (args['Identifier'], data['Sys-Last-Updated'])
 
-        for f in fields:
-            print "<field name='%s'><![CDATA[%s]]></field>" % (encodeHTML(f), encodeCDATA(args[f]))
+            for f in fields:
+                print "<field name='%s'><![CDATA[%s]]></field>" % (encodeHTML(f), encodeCDATA(args[f]))
 
-        print """  </bug>"""
-        printXMLSectionFooter("buglist")
-        printXMLPageFooter()
+            print """  </bug>"""
+            printXMLSectionFooter("buglist")
+            printXMLPageFooter()
 
-    except TiqitException, e:
-        queueMessage(e.type, "Backend Error: %s" % e.output)
-        printXMLPageHeader(extraheaders=['Status: 500'])
-        printXMLMessages()
-        printXMLPageFooter()
+        except TiqitException, e:
+            queueMessage(e.type, "Backend Error: %s" % e.output)
+            printXMLPageHeader(extraheaders=['Status: 500'])
+            printXMLMessages()
+            printXMLPageFooter()

--- a/scripts/helpers/multiedit.py
+++ b/scripts/helpers/multiedit.py
@@ -35,7 +35,7 @@ else:
     is_get_changes_success = True
     for f in fields:
         if not is_get_changes_success:
-            continue
+            break
 
         try:
             changes[allFields[f].savename] = allFields[f].filterEdit(args, args[f])

--- a/scripts/tiqit/__init__.py
+++ b/scripts/tiqit/__init__.py
@@ -45,7 +45,7 @@ times = [("start", time.time())]
 
 MAJ_VER   = 1
 MIN_VER   = 0
-PATCH_VER = 10
+PATCH_VER = 11
 DEV_VER   = 0
 
 VERSION = (MAJ_VER, MIN_VER, PATCH_VER)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from distutils.core import setup
 
 setup(name='tiqit',
-      version="1.0.10",
+      version="1.0.11",
       description='Tiqit: The Intelligent Issue Tracker',
       url='https://launchpad.net/tiqit',
       maintainer='Tiqit maintainers at Ensoft',


### PR DESCRIPTION
Added filterEdit call during multiedit. This will convert all requested field changes to their backend value.

Tested changes on example filterEdit implementations.