### PR TITLE
Don't reset drop-downs to default values during page loads

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+tiqit (1.0.12-1) trusty: urgency=low
+
+  * Fix form entries being reset on page load. Let browser handle resetting
+    of values in the form.
+
+-- Olli Johnson <ollijohnson93@gmail.com>  Thur, 08 Jan 2021 16:54:00 +0000
+
 tiqit (1.0.11-1) trusty; urgency=high
 
   * Use filterEdit functionality to convert modified fields into their

--- a/scripts/tiqit/__init__.py
+++ b/scripts/tiqit/__init__.py
@@ -45,7 +45,7 @@ times = [("start", time.time())]
 
 MAJ_VER   = 1
 MIN_VER   = 0
-PATCH_VER = 11
+PATCH_VER = 12
 DEV_VER   = 0
 
 VERSION = (MAJ_VER, MIN_VER, PATCH_VER)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from distutils.core import setup
 
 setup(name='tiqit',
-      version="1.0.11",
+      version="1.0.12",
       description='Tiqit: The Intelligent Issue Tracker',
       url='https://launchpad.net/tiqit',
       maintainer='Tiqit maintainers at Ensoft',

--- a/static/scripts/view.js
+++ b/static/scripts/view.js
@@ -575,11 +575,6 @@ function updateChildrenView(event) {
                 old_editor.input = old_editor;
             }
 
-            // Go back to the default value if we are not a checkbox
-            if (!(field.childfields[child].nodeName == 'INPUT' && field.childfields[child].type == 'checkbox')) {
-                editor.input.value = old_editor.input.defaultValue;
-            }
-           
             // Add the event listener(s) updateChildrenView and checkFormValidity
             // to the dropdown
             editor.input.addEventListener('change', updateChildrenView, false);


### PR DESCRIPTION
The only functionality this seems to have is to ensure database values are loaded instead of previously inserted values when navigating "back" in the browser. The cost of this is that for new bugs there is no database value so the value gets blanked out when it would be more useful to actually keep the previous value the user inserted.

It's also worth noting that the values that are modified from the DB values are highlighted, so it's clear when there are differences in the loaded state and saved state.