### PR TITLE
bugfix/ET-241

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+tiqit (1.0.13-1) trusty; urgency=low
+
+  * Fix comparing backend and frontend values when editing a defect causing
+    some fields to be submitted as changed despite no change being present.
+
+ -- Olli Johnson <ollijohnson93@gmail.com>  Thu, 27 Jan 2021 12:23:00 +0000
+
 tiqit (1.0.12-1) trusty; urgency=low
 
   * Fix form entries being reset on page load. Let browser handle resetting

--- a/scripts/actions/edit.py
+++ b/scripts/actions/edit.py
@@ -1,7 +1,7 @@
 #! /usr/bin/python
 
 import time
-from backend import *
+from backend import * # allFields
 from tiqit import *
 from frontend import *
 
@@ -54,9 +54,16 @@ for field in [x for x in fieldsInUpdate if allFields[x].editable]:
     old = data[fieldObj.name]
     new = ''
     if args.has_key(field):
-        new = fieldObj.filterEdit(args, args[field])
+        new = args[field]
+
     if old != new:
         changes[fieldObj.name] = new
+
+# Convert any changed fields to the backend format
+changed_fields = [f for f in changes]
+for field in changed_fields:
+    fieldObj = allFields[field]
+    changes[field] = fieldObj.filterEdit(args, args[field])
 
 # Now fix multi value fields
 for field in changes.keys():

--- a/scripts/actions/edit.py
+++ b/scripts/actions/edit.py
@@ -1,7 +1,7 @@
 #! /usr/bin/python
 
 import time
-from backend import * # allFields
+from backend import *
 from tiqit import *
 from frontend import *
 

--- a/scripts/tiqit/__init__.py
+++ b/scripts/tiqit/__init__.py
@@ -45,7 +45,7 @@ times = [("start", time.time())]
 
 MAJ_VER   = 1
 MIN_VER   = 0
-PATCH_VER = 12
+PATCH_VER = 13
 DEV_VER   = 0
 
 VERSION = (MAJ_VER, MIN_VER, PATCH_VER)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from distutils.core import setup
 
 setup(name='tiqit',
-      version="1.0.12",
+      version="1.0.13",
       description='Tiqit: The Intelligent Issue Tracker',
       url='https://github.com/ensoft/tiqit',
       maintainer='Tiqit maintainers at Ensoft',

--- a/tiqitlib/setup.py
+++ b/tiqitlib/setup.py
@@ -6,7 +6,7 @@
 from distutils.core import setup
 
 setup(name='tiqitlib',
-      version="1.0.12",
+      version="1.0.13",
       description='Python library for Tiqit: The Intelligent Issue Tracker',
       url='https://github.com/ensoft/tiqit',
       maintainer='Tiqit maintainers at Ensoft',


### PR DESCRIPTION
Testing included:
* Setting "component" on a bug and modifying the "manager" to a non-default value.
* Then, updating any other value on the bug and confirming that the "manager" field is not reset to the default for the "component"
* This was previously an issue since "component" is a bug field with a separate front-end and back-end format which was always being seen as modified which was in turn resetting other fields including "manager" to the default values.