### PR TITLE
Bugfix/newlines in notes disappearing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,8 @@ tiqit (1.0.13-1) trusty; urgency=low
 
   * Fix comparing backend and frontend values when editing a defect causing
     some fields to be submitted as changed despite no change being present.
+  * Replace newlines with unicode characters when communicating between the
+    front and backend to work around limitations in OIDC redirects.
 
  -- Olli Johnson <ollijohnson93@gmail.com>  Thu, 27 Jan 2021 12:23:00 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,8 +2,8 @@ tiqit (1.0.13-1) trusty; urgency=low
 
   * Fix comparing backend and frontend values when editing a defect causing
     some fields to be submitted as changed despite no change being present.
-  * Replace newlines with unicode characters when communicating between the
-    front and backend to work around limitations in OIDC redirects.
+  * Fix issues with OIDC redirects causing newlines in enclosures to be
+    removed after session timeouts.
 
  -- Olli Johnson <ollijohnson93@gmail.com>  Thu, 27 Jan 2021 12:23:00 +0000
 

--- a/scripts/actions/editnote.py
+++ b/scripts/actions/editnote.py
@@ -28,7 +28,13 @@ else:
         # Save the new name for the next step
         noteTitle = newTitle
 
+    # Replace unicode line-separator characters with standard newlines
+    # These are inserted by the JS to avoid newlines being urlencoded and lost
+    # during redirects through OIDC.
+    noteContent = args['noteContent']
+    noteContent = noteContent.replace(u'\u2028', '\n')
+
     # Now update/create the note
-    addNote(bugid, noteType, noteTitle, args['noteContent'], args.has_key('isUpdate'))
+    addNote(bugid, noteType, noteTitle, noteContent, args.has_key('isUpdate'))
 
 redirect('%s' % bugid)

--- a/scripts/pages/view.py
+++ b/scripts/pages/view.py
@@ -270,7 +270,7 @@ def displayNotes(hide=False):
         print "<p>No Enclosures or Attachments.</p>"
     else:
         print """
-    <form action='editnote.py' method='post'>
+    <form action='editnote.py' onsubmit='onSubmitEnclosure()' method='post'>
     <input type='hidden' name='bugid' value='%s'>
     <input type='hidden' name='isUpdate' value='true'>
     <div id='encTableContainer'>
@@ -298,7 +298,7 @@ def displayNotes(hide=False):
 </p>
 <div id='newnote' class='note' style='display: none;'>
  <p>Add new Enclosure:</p>
- <form action='editnote.py' method='post'>
+ <form action='editnote.py' onsubmit='onSubmitEnclosure()' method='post'>
   <input type='hidden' name='bugid' value='%s'>
   <table>
    <tr>

--- a/static/scripts/view.js
+++ b/static/scripts/view.js
@@ -79,6 +79,7 @@ addCustomEventListener("FirstWindowLoad", calDropDownInit);
 
 // The object currently being edited.
 var amEditing = null;
+var amEditingTextarea = null;
 
 var editMsg = "You have already changed another section of this bug.\nYou may only edit one section at a time.\n\nPlease save those changes, or undo them, then try again."
 
@@ -178,6 +179,7 @@ function editEnclosure(button) {
   button.style.display = 'none';
 
   amEditing = row;
+  amEditingTextarea = textBox;
 }
 
 function cancelEnclosureEdit(button) {
@@ -213,6 +215,19 @@ function cancelEnclosureEdit(button) {
   button.style.display = 'inline';
 
   amEditing = null;
+  amEditingTextarea = null;
+}
+
+function onSubmitEnclosure() {
+  if (amEditingTextarea) {
+    /*
+     * Replace line endings with the unicode line-separator as this doesn't get
+     * interpreted and lost during urlencoding.
+     * This avoids an issue where urlencoded newliens get dropped during
+     * redirects through OIDC.
+     */
+    amEditingTextarea.value = amEditingTextarea.value.replace(/\r?\n/g, "\u2028")
+  }
 }
 
 function deleteEnclosure(button) {


### PR DESCRIPTION
Tested with newlines on firefox and chrome. Solution works both with and without OIDC session expiry (tested by deleting session cookies).
Also checked for other special characters. Spaces, tabs, percentage symbols, exclamation and question marks etc all work fine so no further work should be needed.