### PR TITLE
Fix the OIDC textarea handling by separating into "edit" and "send" areas

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+tiqit (1.0.14-1) trusty; urgency=low
+
+  * Fix issues with OIDC redirects causing newlines in summaries and RNE
+    fields and improve the same handling for enclosures.
+
+ -- Olli Johnson <ollijohnson93@gmail.com>  Mon, 15 Aug 2022 11:23:00 +0000
+
 tiqit (1.0.13-1) trusty; urgency=low
 
   * Fix comparing backend and frontend values when editing a defect causing

--- a/scripts/actions/edit.py
+++ b/scripts/actions/edit.py
@@ -7,10 +7,6 @@ from frontend import *
 
 args = Arguments()
 
-for x in args:
-    # Replace unicode newlines with regular newlines in all fields
-    args[x] = args[x].replace(u'\u2028', '\n')
-
 #
 # First thing we want to do is make sure we're not scribbling over any
 # changes made by someone else.

--- a/scripts/actions/edit.py
+++ b/scripts/actions/edit.py
@@ -7,6 +7,10 @@ from frontend import *
 
 args = Arguments()
 
+for x in args:
+    # Replace unicode newlines with regular newlines in all fields
+    args[x] = args[x].replace(u'\u2028', '\n')
+
 #
 # First thing we want to do is make sure we're not scribbling over any
 # changes made by someone else.
@@ -60,8 +64,7 @@ for field in [x for x in fieldsInUpdate if allFields[x].editable]:
         changes[fieldObj.name] = new
 
 # Convert any changed fields to the backend format
-changed_fields = [f for f in changes]
-for field in changed_fields:
+for field in changes:
     fieldObj = allFields[field]
     changes[field] = fieldObj.filterEdit(args, args[field])
 

--- a/scripts/fields.py
+++ b/scripts/fields.py
@@ -467,7 +467,12 @@ def filterDisplayEditableText(field, data, val):
     return display
 
 def filterDisplayEditableSummary(field, data, val):
-    display = "<textarea id='%s' name='%s' rows='%d' cols='%d' onChange='checkFormValidity(event);'>%s</textarea>" % (field.name, field.name, field.rows, field.displaylen, val)
+    display = (
+        "<textarea id='{0}' rows='{1}' cols='{2}' "
+        "onChange='checkFormValidity(event);'>{3}</textarea>"
+        "<textarea id='{0}Send' name='{0}' style='display: none'></textarea>"
+        "<script type='text/javascript'>textareasToSubmit.push(['{0}', '{0}Send'])</script>"
+    ).format(field.name, field.rows, field.displaylen, val)
     return display
 
 def filterDisplayEditableDefect(field, data, val):

--- a/scripts/pages/newbug.py
+++ b/scripts/pages/newbug.py
@@ -82,7 +82,7 @@ print """
 <h1>
   %s
 </h1>
-<form id='tiqitNewBug' action='submit.py' method='post' onsubmit='if (!checkFormValidity()) return confirm("Missing info in form. Submit anyway?");'>""" % pageTitle
+<form name='tiqitNewBug' action='submit.py' method='post' onsubmit='onSubmitPage(); if (!checkFormValidity()) return confirm("Missing info in form. Submit anyway?");'>""" % pageTitle
 
 print "<p>Creating new "
 

--- a/scripts/pages/newbug.py
+++ b/scripts/pages/newbug.py
@@ -82,7 +82,7 @@ print """
 <h1>
   %s
 </h1>
-<form name='tiqitNewBug' action='submit.py' method='post' onsubmit='onSubmitPage(); if (!checkFormValidity()) return confirm("Missing info in form. Submit anyway?");'>""" % pageTitle
+<form id='tiqitNewBug' action='submit.py' method='post' onsubmit='onSubmitPage(); if (!checkFormValidity()) return confirm("Missing info in form. Submit anyway?");'>""" % pageTitle
 
 print "<p>Creating new "
 

--- a/scripts/pages/view.py
+++ b/scripts/pages/view.py
@@ -227,7 +227,7 @@ def displayGeneral(hide=False):
     primarytitle, primarytitleDetail, primaryformat = view_sections[0]
     printSectionHeader(primarytitle, primarytitleDetail, hide);
 
-    print "<form name='tiqitBugEdit' action='edit.py' method='post' onSubmit='return prepareForm();'>"
+    print "<form id='tiqitBugEdit' action='edit.py' method='post' onSubmit='return prepareForm();'>"
     print cls.getFormat(primaryformat) % args
 
     print """
@@ -248,7 +248,7 @@ def displayExtra(hide=False):
         print cls.getFormat(format) % args
         print """
 
-<p><input type='button' value='Save Changes' onClick='if (prepareForm()) document.getElementsByName("tiqitBugEdit")[0].submit();'></p>
+<p><input type='button' value='Save Changes' onClick='if (prepareForm()) document.getElementById("tiqitBugEdit").submit();'></p>
 """
 
         printSectionFooter()
@@ -594,7 +594,7 @@ def displayRelates(hide=False):
       </tr>
      </table>
     </p>
-    <p><input type='button' value='Save Changes' onClick='if (prepareForm()) document.getElementsByName("tiqitBugEdit")[0].submit();'></p>
+    <p><input type='button' value='Save Changes' onClick='if (prepareForm()) document.getElementById("tiqitBugEdit").submit();'></p>
     -->
     """
 

--- a/scripts/pages/view.py
+++ b/scripts/pages/view.py
@@ -295,9 +295,12 @@ def displayNotes(hide=False):
         print "</table></div></form>"
 
     # And the 'new' section, for adding enclosures
-    # Note the textareas are split into "Edit" and a hidden "Send" to replace
-    # newlines with unicode characters when sending to the server to work
-    # around a known auth issue with OIDC.
+    # Note the textareas are split into "Edit", which is visible to the user
+    # but it's value isn't sent directly to the server, and a hidden "Send",
+    # which has its value sent to the server. When the form is submitted, the
+    # value of the "Edit" textarea has the newlines replaced with unicode
+    # characters and this new value is inserted into the "Send" textarea.
+    # This works around a known auth issue with OIDC.
     # Having separate boxes avoids issues where the note fails submit, the user
     # navigates back to edit the note again but now sees it with the unicode
     # characters present instead of the newlines. Most browsers don't render

--- a/scripts/pages/view.py
+++ b/scripts/pages/view.py
@@ -229,7 +229,7 @@ def displayGeneral(hide=False):
     primarytitle, primarytitleDetail, primaryformat = view_sections[0]
     printSectionHeader(primarytitle, primarytitleDetail, hide);
 
-    print "<form id='tiqitBugEdit' action='edit.py' method='post' onSubmit='return prepareForm();'>"
+    print "<form name='tiqitBugEdit' action='edit.py' method='post' onSubmit='return prepareForm();'>"
     print cls.getFormat(primaryformat) % args
 
     print """
@@ -250,7 +250,7 @@ def displayExtra(hide=False):
         print cls.getFormat(format) % args
         print """
 
-<p><input type='button' value='Save Changes' onClick='if (prepareForm()) document.getElementById("tiqitBugEdit").submit();'></p>
+<p><input type='button' value='Save Changes' onClick='if (prepareForm()) document.getElementsByName("tiqitBugEdit")[0].submit();'></p>
 """
 
         printSectionFooter()
@@ -596,7 +596,7 @@ def displayRelates(hide=False):
       </tr>
      </table>
     </p>
-    <p><input type='button' value='Save Changes' onClick='if (prepareForm()) document.getElementById("tiqitBugEdit").submit();'></p>
+    <p><input type='button' value='Save Changes' onClick='if (prepareForm()) document.getElementsByName("tiqitBugEdit")[0].submit();'></p>
     -->
     """
 

--- a/scripts/pages/view.py
+++ b/scripts/pages/view.py
@@ -167,8 +167,6 @@ def showPage():
                     ('History', displayHistory),
                     ('Relates', displayRelates)]
 
-    # @@@ - Should likely be including the security section in this and removing
-    # the save changes button etc as part of that
     viewSections.extend(plugins.getViewSections())
 
     # Show/hide sections as requested by prefs

--- a/scripts/pages/view.py
+++ b/scripts/pages/view.py
@@ -86,7 +86,11 @@ class Note(object):
          </td>
         </tr>
         <tr class='note' style='display: none;'>
-         <td colspan='7'><pre>%(Note)s</pre></td>
+         <td colspan='7'>
+            <pre>%(Note)s</pre>
+            <textarea style='display: none;' class='edit'>%(Note)s</textarea>
+            <textarea style='display: none;' class='send'></textarea>
+         </td>
         </tr>
         """ % self.info
 
@@ -163,6 +167,8 @@ def showPage():
                     ('History', displayHistory),
                     ('Relates', displayRelates)]
 
+    # @@@ - Should likely be including the security section in this and removing
+    # the save changes button etc as part of that
     viewSections.extend(plugins.getViewSections())
 
     # Show/hide sections as requested by prefs
@@ -291,6 +297,13 @@ def displayNotes(hide=False):
         print "</table></div></form>"
 
     # And the 'new' section, for adding enclosures
+    # Note the textareas are split into "Edit" and a hidden "Send" to replace
+    # newlines with unicode characters when sending to the server to work
+    # around a known auth issue with OIDC.
+    # Having separate boxes avoids issues where the note fails submit, the user
+    # navigates back to edit the note again but now sees it with the unicode
+    # characters present instead of the newlines. Most browsers don't render
+    # the unicode characters at all.
     print """
 <p id='newencbuttons'>
  <input type='button' value='New Note' onclick='showNewNote();'>
@@ -309,7 +322,8 @@ def displayNotes(hide=False):
    </tr>
    <tr>
     <td colspan='4'>
-     <textarea id='newnotecontent' name='noteContent' style='width: 100%%' rows='18'></textarea>
+     <textarea class="edit" style='width: 100%%' rows='18'></textarea>
+     <textarea class="send" name='noteContent' style='display: none'></textarea>
     </td>
    </tr>
   </table>

--- a/scripts/pages/view.py
+++ b/scripts/pages/view.py
@@ -88,7 +88,7 @@ class Note(object):
         <tr class='note' style='display: none;'>
          <td colspan='7'>
             <pre>%(Note)s</pre>
-            <textarea style='display: none;' class='edit'>%(Note)s</textarea>
+            <textarea style='display: none;' class='edit' rows='18'>%(Note)s</textarea>
             <textarea style='display: none;' class='send'></textarea>
          </td>
         </tr>

--- a/scripts/tiqit/__init__.py
+++ b/scripts/tiqit/__init__.py
@@ -45,7 +45,7 @@ times = [("start", time.time())]
 
 MAJ_VER   = 1
 MIN_VER   = 0
-PATCH_VER = 13
+PATCH_VER = 14
 DEV_VER   = 0
 
 VERSION = (MAJ_VER, MIN_VER, PATCH_VER)
@@ -145,12 +145,15 @@ class Arguments(object):
         return string
 
     def __getitem__(self, key):
+        val = ''
         if self.overrides.has_key(key):
-            return self.overrides[key]
+            val = self.overrides[key]
         elif self.cgi.has_key(key):
-            return self.cgi[key].value.decode('utf-8')
-        else:
-            return ''
+            val = self.cgi[key].value.decode('utf-8')
+
+        # Replace unicode newlines with regular newlines
+        # in any argument values
+        return val.replace(u'\u2028', '\n')
 
     def __setitem__(self, key, val):
         self.overrides[key] = val

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from distutils.core import setup
 
 setup(name='tiqit',
-      version="1.0.13",
+      version="1.0.14",
       description='Tiqit: The Intelligent Issue Tracker',
       url='https://github.com/ensoft/tiqit',
       maintainer='Tiqit maintainers at Ensoft',

--- a/static/scripts/view.js
+++ b/static/scripts/view.js
@@ -220,18 +220,30 @@ function cancelEnclosureEdit(button) {
   button.style.display = 'inline';
 }
 
-function onSubmitEnclosure() {
+function onSubmitTextarea(editid, sendid) {
   /*
    * Replace line endings with the unicode line-separator as this doesn't get
    * interpreted and lost during urlencoding.
    * This avoids an issue where urlencoded newliens get dropped during
    * redirects through OIDC.
    */
-  let noteContentEdit = document.getElementById("noteContentEdit");
-  let noteContentSend = document.getElementById("noteContentSend");
-  if (noteContentEdit && noteContentSend) {
-    noteContentSend.value = noteContentEdit.value.replace(/\r?\n/g, "\u2028");
+  let editEle = document.getElementById(editid);
+  let sendEle = document.getElementById(sendid);
+  if (editEle && sendEle) {
+    sendEle.value = editEle.value.replace(/\r?\n/g, "\u2028");
   }
+}
+
+function onSubmitEnclosure() {
+  onSubmitTextarea("noteContentEdit", "noteContentSend");
+}
+
+var textareasToSubmit = [];
+
+function onSubmitPage() {
+  textareasToSubmit.forEach((v) => {
+    onSubmitTextarea(v[0], v[1]);
+  });
 }
 
 function deleteEnclosure(button) {
@@ -543,7 +555,7 @@ function checkS1S2Downgrade() {
       S1S2.setAttribute('id', 'S1S2-without-workaround');
       S1S2.setAttribute('name', 'S1S2-without-workaround');
 
-      document.getElementById('tiqitBugEdit').appendChild(S1S2);
+      document.getElementsByName('tiqitBugEdit')[0].appendChild(S1S2);
     }
 
     S1S2.value = confirm("If you are downgrading the Severity because there\n" +
@@ -563,7 +575,7 @@ function getFieldValueView(field) {
 
 function resetForm() {
     // Want to reset both initial form and extras form.
-    document.getElementById("tiqitBugEdit").reset();
+    document.getElementsByName("tiqitBugEdit")[0].reset();
     document.getElementById("tiqitExtraFormData").reset();
 
     // Also clear the indicator on the Component name if it has been set - 
@@ -713,7 +725,7 @@ function checkFormValidity(event) {
     }
   }
 
-  var form = document.getElementById('tiqitBugEdit');
+  var form = document.getElementsByName('tiqitBugEdit')[0];
   var f, l;
   var bannedif_field;
   var mandatoryif_field;
@@ -832,7 +844,8 @@ function checkFormValidity(event) {
 //
 
 function prepareForm() {
-  var form = document.getElementById('tiqitBugEdit');
+  onSubmitPage();
+  var form = document.getElementsByName('tiqitBugEdit')[0];
   var extra = document.getElementById('tiqitExtraFormData');
 
   var inputs = extra.getElementsByTagName('input');

--- a/static/scripts/view.js
+++ b/static/scripts/view.js
@@ -140,15 +140,21 @@ function editEnclosure(button) {
 
   showEnclosure(row);
 
-  // Mark the textareas as being edited
-  var pre = table.rows[row.rowIndex + 1].cells[0].getElementsByTagName("pre")[0];
+  /*
+   * Mark the textareas as being edited - see view.py for explanation of
+   * "edit" vs "send" areas.
+   */
   var textareaEdit = table.rows[row.rowIndex + 1].cells[0].getElementsByClassName("edit")[0];
   textareaEdit.id = 'noteContentEdit';
   var textareaSend = table.rows[row.rowIndex + 1].cells[0].getElementsByClassName("send")[0];
   textareaSend.id = 'noteContentSend';
   textareaSend.name = 'noteContent';
 
-  // Hide the <pre> and display the <textarea>
+  /*
+   * Hide the <pre> and display the <textarea>
+   * The "pre" is the non-editable view of the note.
+   */
+  var pre = table.rows[row.rowIndex + 1].cells[0].getElementsByTagName("pre")[0];
   pre.style.display = 'none';
   textareaEdit.style.display = 'block';
 
@@ -226,7 +232,7 @@ function onSubmitTextarea(editid, sendid) {
   /*
    * Replace line endings with the unicode line-separator as this doesn't get
    * interpreted and lost during urlencoding.
-   * This avoids an issue where urlencoded newliens get dropped during
+   * This avoids an issue where urlencoded newlines get dropped during
    * redirects through OIDC.
    */
   let editEle = document.getElementById(editid);
@@ -438,7 +444,10 @@ function showNewNote() {
   theButton.style.display = "none";
 
 
-  // Mark the textareas as being edited
+  /*
+   * Mark the textareas as being edited - see view.py for explanation of
+   * "edit" vs "send" areas.
+   */
   var form = newNote.getElementsByTagName("form")[0];
   var textareaEdit = form.getElementsByClassName("edit")[0];
   textareaEdit.id = 'noteContentEdit';
@@ -461,7 +470,10 @@ function hideNewNote() {
   newNote.style.display = "none";
   theButton.style.display = "inline";
 
-  // Mark the textareas as no longer being edited
+  /*
+   * Mark the textareas as no longer being edited - see view.py for
+   * explanation of "edit" vs "send" areas.
+   */
   var form = newNote.getElementsByTagName("form")[0];
   var textareaEdit = form.getElementsByClassName("edit")[0];
   textareaEdit.id = '';

--- a/tiqitlib/setup.py
+++ b/tiqitlib/setup.py
@@ -6,7 +6,7 @@
 from distutils.core import setup
 
 setup(name='tiqitlib',
-      version="1.0.13",
+      version="1.0.14",
       description='Python library for Tiqit: The Intelligent Issue Tracker',
       url='https://github.com/ensoft/tiqit',
       maintainer='Tiqit maintainers at Ensoft',


### PR DESCRIPTION
Testing includes performing the following actions with an "expired" (deleted) OIDC token and observing fields are as expected with newlines intact.
* Creating new bug including newlines in all textareas
* Editing summary field of new bug with newlines
* Adding new note with newlines
* Editing existing note with newlines

The following is known not to work with an "expired" (deleted) OIDC token, more work is needed:
* Adding a new attachment (file) to a bug

It has been confirmed that when errors are hit navigating "back" to the form leaves it in a sane state, where previously newlines had been replaced with unicode characters that the browser did not render.
