### PR TITLE
Stop users hitting JS cache issues with new releases

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+tiqit (1.1.2-1) trusty; urgency=low
+
+  * Avoid users needing to clear browser cache when tiqit or plugin versions
+    are updated.
+
+ -- Olli Johnson <ollijohnson93@gmail.com>  Thu, 24 Nov 2022 11:17:00 +0000
+
 tiqit (1.1.1-1) trusty; urgency=low
 
   * Update the hash function for TiqitField to work for 'viewname' values

--- a/scripts/tiqit/__init__.py
+++ b/scripts/tiqit/__init__.py
@@ -1118,40 +1118,57 @@ def printPageHeader(pageName, pageTitle="", initScript=None, otherHeaders=[],
     <base href='%s'>
     <link rel='apple-touch-icon' href='%s'>
     <link rel='shortcut icon' type='%s' href='%s'>
-    <link rel='stylesheet' type='text/css' href='styles/print.css' media='print'>""" % (pageTitle, baseurl, pages[pageName].site.appleiconurl, pages[pageName].site.imgtype, pages[pageName].site.imgurl))
+    <link rel='stylesheet' type='text/css' href='styles/print.css?version=%s' media='print'>""" % (
+            pageTitle,
+            baseurl,
+            pages[pageName].site.appleiconurl,
+            pages[pageName].site.imgtype,
+            pages[pageName].site.imgurl,
+            VERSION_STRING,
+        )
+    )
     
     for head in otherHeaders:
         print(head)
 
     # Print styles
-    print("<link rel='stylesheet' type='text/css' href='styles/tiqit.css' media='screen'>")
+    print("<link rel='stylesheet' type='text/css' href='styles/tiqit.css?version=%s' media='screen'>" % VERSION_STRING)
     for style in pages[pageName].styles:
-        print("<link rel='stylesheet' type='text/css' href='styles/%s.css' media='screen'>" % style)
+        print("<link rel='stylesheet' type='text/css' href='styles/%s.css?version=%s' media='screen'>" % (style, VERSION_STRING))
 
     # Plugins may want to add styles too
     for style in plugins.getPageStyles(pageName):
-        print("<link rel='stylesheet' type='text/css' href='styles/%s.css' media='screen'>" % style)
+        print("<link rel='stylesheet' type='text/css' href='styles/%s.css?version=%s' media='screen'>" % (style, VERSION_STRING))
 
     # Print custom styles (overrides any other styles)
     cfg_section = Config().section('general')
     if 'customstyles' in cfg_section:
         for style in cfg_section.getlist('customstyles'):
-            print("<link rel='stylesheet' type='text/css' " + 
-                   "href='%s' media='screen'>") % style
+            print(("<link rel='stylesheet' type='text/css' " + 
+                   "href='%s?version=%s' media='screen'>") % (style, VERSION_STRING))
 
-    print("<script type='text/javascript' src='scripts/tiqit.js'></script>")
-    print("<script type='text/javascript' src='scripts/Sortable.js'></script>")
+    print("<script type='text/javascript' src='scripts/tiqit.js?version=%s'></script>" % VERSION_STRING)
+    print("<script type='text/javascript' src='scripts/Sortable.js?version=%s'></script>" % VERSION_STRING)
     
     for script in pages[pageName].scripts: 
-        print("<script type='text/javascript' src='scripts/%s.js'></script>" % script)
+        print("<script type='text/javascript' src='scripts/%s.js?version=%s'></script>" % (script, VERSION_STRING))
 
     # Plugins may want to add scripts too
     for script in plugins.getPageScripts(pageName):
-        print("<script type='text/javascript' src='scripts/%s.js'></script>" % script)
+        # The plugin may provide a version along with the script
+        # in which case it is added to the tiqit version
+        pluginVersion = ""
+        if isinstance(script, tuple):
+            script, plugin_version = script
+        print("<script type='text/javascript' src='scripts/%s.js?version=%s+%s'></script>" % (
+            script,
+            VERSION_STRING,
+            plugin_version
+        ))
 
     if bugView:
-        print("<link rel='stylesheet' type='text/css' href='styles/%s.css' media='screen'>" % bugView.name)
-        print("<script type='text/javascript' src='scripts/%s.js'></script>" % bugView.name)
+        print("<link rel='stylesheet' type='text/css' href='styles/%s.css?version=%s' media='screen'>" % (bugView.name, VERSION_STRING))
+        print("<script type='text/javascript' src='scripts/%s.js?version=%s'></script>" % (bugView.name, VERSION_STRING))
 
     print("""
     <script type='text/javascript'>

--- a/scripts/tiqit/__init__.py
+++ b/scripts/tiqit/__init__.py
@@ -1138,7 +1138,16 @@ def printPageHeader(pageName, pageTitle="", initScript=None, otherHeaders=[],
 
     # Plugins may want to add styles too
     for style in plugins.getPageStyles(pageName):
-        print("<link rel='stylesheet' type='text/css' href='styles/%s.css?version=%s' media='screen'>" % (style, VERSION_STRING))
+        # The plugin may provide a version along with the script
+        # in which case it is added to the tiqit version
+        pluginVersion = ""
+        if isinstance(script, tuple):
+            script, plugin_version = script
+        print("<link rel='stylesheet' type='text/css' href='styles/%s.css?version=%s' media='screen'>" % (
+            style,
+            VERSION_STRING,
+            plugin_version
+        ))
 
     # Print custom styles (overrides any other styles)
     cfg_section = Config().section('general')

--- a/scripts/tiqit/__init__.py
+++ b/scripts/tiqit/__init__.py
@@ -1141,8 +1141,8 @@ def printPageHeader(pageName, pageTitle="", initScript=None, otherHeaders=[],
         # The plugin may provide a version along with the script
         # in which case it is added to the tiqit version
         pluginVersion = ""
-        if isinstance(script, tuple):
-            script, plugin_version = script
+        if isinstance(style, tuple):
+            style, plugin_version = style
         print("<link rel='stylesheet' type='text/css' href='styles/%s.css?version=%s' media='screen'>" % (
             style,
             VERSION_STRING,

--- a/scripts/tiqit/__init__.py
+++ b/scripts/tiqit/__init__.py
@@ -45,7 +45,7 @@ times = [("start", time.time())]
 
 MAJ_VER   = 1
 MIN_VER   = 1
-PATCH_VER = 1
+PATCH_VER = 2
 DEV_VER   = 1
 
 VERSION = (MAJ_VER, MIN_VER, PATCH_VER)

--- a/scripts/tiqit/__init__.py
+++ b/scripts/tiqit/__init__.py
@@ -1140,10 +1140,10 @@ def printPageHeader(pageName, pageTitle="", initScript=None, otherHeaders=[],
     for style in plugins.getPageStyles(pageName):
         # The plugin may provide a version along with the script
         # in which case it is added to the tiqit version
-        pluginVersion = ""
+        plugin_version = ""
         if isinstance(style, tuple):
             style, plugin_version = style
-        print("<link rel='stylesheet' type='text/css' href='styles/%s.css?version=%s' media='screen'>" % (
+        print("<link rel='stylesheet' type='text/css' href='styles/%s.css?version=%s+%s' media='screen'>" % (
             style,
             VERSION_STRING,
             plugin_version
@@ -1166,7 +1166,7 @@ def printPageHeader(pageName, pageTitle="", initScript=None, otherHeaders=[],
     for script in plugins.getPageScripts(pageName):
         # The plugin may provide a version along with the script
         # in which case it is added to the tiqit version
-        pluginVersion = ""
+        plugin_version = ""
         if isinstance(script, tuple):
             script, plugin_version = script
         print("<script type='text/javascript' src='scripts/%s.js?version=%s+%s'></script>" % (

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from distutils.core import setup
 
 setup(name='tiqit',
-      version="1.1.1",
+      version="1.1.2",
       description='Tiqit: The Intelligent Issue Tracker',
       url='https://github.com/ensoft/tiqit',
       maintainer='Tiqit maintainers at Ensoft',

--- a/tiqitlib/setup.py
+++ b/tiqitlib/setup.py
@@ -6,7 +6,7 @@
 from distutils.core import setup
 
 setup(name='tiqitlib',
-      version="1.1.1",
+      version="1.1.2",
       description='Python library for Tiqit: The Intelligent Issue Tracker',
       url='https://github.com/ensoft/tiqit',
       maintainer='Tiqit maintainers at Ensoft',


### PR DESCRIPTION
Add version query params to all css and js sources so cache is not used when versions uprev.

Testing includes:
* Loading page and observing cache not used for any JS/CSS files
* Refreshing page and seeing cache used for all JS/CSS files
* Updating patch version number in tiqit
* Refreshing page and seeing cache not used for any JS/CSS files (new version number in request)
* Refreshing page again and seeing cache used for all JS/CSS files