### PR TITLE
Update hash function to account for "None" values in viewnames

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+tiqit (1.1.1-1) trusty; urgency=low
+
+  * Update the hash function for TiqitField to work for 'viewname' values
+    set to None.
+
+ -- Jonathan Loh <joloh@cisco.com> Mon, 2 Jan 2024 18:47:00 +0000
+
 tiqit (1.1.0-1) trusty; urgency=low
 
   * Migrate all scripts from using python2 to python3.

--- a/scripts/fields.py
+++ b/scripts/fields.py
@@ -423,9 +423,10 @@ class TiqitField(object):
 
     def __hash__(self):
         # Create a unique string to represent each TiqitField instance
-        # and then hash it.        
+        # and then hash it. 'viewname' may be set to "None" if it does not
+        # exist in the backend.
         return hash(self.name + 
-            " ".join(self.viewnames) + 
+            " ".join((str(viewname) for viewname in self.viewnames)) +
             " " + self.longname + " " + 
             self.shortname)
 

--- a/scripts/tiqit/__init__.py
+++ b/scripts/tiqit/__init__.py
@@ -45,7 +45,7 @@ times = [("start", time.time())]
 
 MAJ_VER   = 1
 MIN_VER   = 1
-PATCH_VER = 0
+PATCH_VER = 1
 DEV_VER   = 1
 
 VERSION = (MAJ_VER, MIN_VER, PATCH_VER)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from distutils.core import setup
 
 setup(name='tiqit',
-      version="1.1.0",
+      version="1.1.1",
       description='Tiqit: The Intelligent Issue Tracker',
       url='https://github.com/ensoft/tiqit',
       maintainer='Tiqit maintainers at Ensoft',

--- a/tiqitlib/setup.py
+++ b/tiqitlib/setup.py
@@ -6,7 +6,7 @@
 from distutils.core import setup
 
 setup(name='tiqitlib',
-      version="1.1.0",
+      version="1.1.1",
       description='Python library for Tiqit: The Intelligent Issue Tracker',
       url='https://github.com/ensoft/tiqit',
       maintainer='Tiqit maintainers at Ensoft',


### PR DESCRIPTION
The py2 to py3 migration implemented a hash function for TiqitField objects (https://github.com/ensoft/tiqit/commit/7fda34609b6bdb17ea8cd30c9533c43d10055dae#diff-a90175214cd6b0c7c0e74d6c52a8c52c9f866a5547269d0a48e708fc94e3aeafR424). However, this did not account for viewname values being set to None. 

This PR aims to account for this.