### PR TITLE
Bugbox bug ID extraction now uses plugin functions

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,8 +2,9 @@ tiqit (1.1.2-1) trusty; urgency=low
 
   * Avoid users needing to clear browser cache when tiqit or plugin versions
     are updated.
+  * Use plugins to obtain bug IDs.
 
- -- Olli Johnson <ollijohnson93@gmail.com>  Thu, 24 Nov 2022 11:17:00 +0000
+ -- Olli Johnson <ollijohnson93@gmail.com>  Thu, 24 Jan 2024 11:17:00 +0000
 
 tiqit (1.1.1-1) trusty; urgency=low
 

--- a/scripts/tiqit/__init__.py
+++ b/scripts/tiqit/__init__.py
@@ -80,26 +80,21 @@ Status: %d
 # Bug ID extractor
 #
 
-def extractBugIds(string):
+def extractBugIds(source_string):
     """
-    Extract anything and everything that looks like a bug id from the
-    given string. Will also normalise bugids (so can be used to
-    normalise tqtSd12345 into TQTsd12345).
+    Extract bug IDs from a string.
+
+    This function utilises plugin code - the getBugIds API.
+
+    Sample input:
+    'This is a bug tqtSd12345 I am looking for.'
+
+    Sample output (note that the getBugIds API is expected to normalise any
+    found bug IDs):
+    ["TQTsd12345"]
+
     """
-
-    backends = (k for k, v in Config().section('backends').items())
-    match = re.findall(r"(?:_|\b)((?:%s)?[A-Z][A-Z]\d\d\d\d\d)(?:_|\b)" %
-                           "|".join(backends),
-                       string,
-                       re.I | re.M)
-
-    if match:
-        bugids = [x[:3].upper() + x[3:].lower() for x in match]
-    else:
-        bugids = []
-
-    return list(dict.fromkeys(bugids))
-    return plugins.findBugIds(string)
+    return plugins.getBugIds(source_string)
 
 #
 # Arguments


### PR DESCRIPTION
Make bug ID extraction from a block of text customisable per plugin.

This has been tested with previously problematic strings and has been shown to work.