### PR TITLE
Fixup admin detection and python3 entry.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,8 @@ tiqit (1.1.2-1) trusty; urgency=low
     are updated.
   * Use plugins to obtain bug IDs.
   * Support multiple update cookies to allow for multiple messages.
+  * Specify python3 as part of the setup script.
+  * Fixup administrator detection.
 
  -- Olli Johnson <ollijohnson93@gmail.com>  Thu, 24 Jan 2024 11:17:00 +0000
 

--- a/scripts/tiqit/__init__.py
+++ b/scripts/tiqit/__init__.py
@@ -326,7 +326,7 @@ CFG_DIRS = ["../",
 #
 
 def getAdministrators():
-    return tuple(Config().section('general').getlist('administrators'))
+    return tuple([admin.strip(", \t") for admin in Config().section('general').getlist('administrators')])
 
 #
 # Authentication (for hypothetical future CLI)

--- a/setup
+++ b/setup
@@ -47,7 +47,7 @@ sed -i -e "s|RewriteBase .*|RewriteBase $NEWBASE|" .htaccess
 # Skip updating data files if we're just creating a .deb: These aren't included
 # in the deb anyway.
 if [ "$PACKAGEMODE" != true ]; then
-    python -c "import pickle; pickle.dump({}, open('data/tiqit.pickle', 'wb'))"
+    python3 -c "import pickle; pickle.dump({}, open('data/tiqit.pickle', 'wb'))"
     echo > static/scripts/fielddata.js
 
     cd scripts


### PR DESCRIPTION
Fixup admin detection to account for other characters.

Specify "python3" in the setup script, instead of using whatever the system has "python" aliased to.